### PR TITLE
Make PersistentVector a subtype of AbstractArray{T,1} instead of AbstractArray{T}

### DIFF
--- a/src/PersistentVector.jl
+++ b/src/PersistentVector.jl
@@ -127,7 +127,7 @@ end
 # Persistent Vectors
 # ==================
 
-immutable PersistentVector{T} <: AbstractArray{T}
+immutable PersistentVector{T} <: AbstractArray{T,1}
     trie::DenseBitmappedTrie{Vector{T}}
     tail::Vector{T}
     length::Int


### PR DESCRIPTION
I ran into this with

``` julia
julia> a = @Persistent [1,2,3]
Persistent{Int64}[1, 2, 3]

julia> b = @Persistent [2,3,4]
Persistent{Int64}[2, 3, 4]

julia> s = Set(a,b)
Set{PersistentVector{Int64}}(Evaluation succeeded, but an error occurred while showing value of type Set{PersistentVector{Int64}}:
ERROR: no method display(Set{PersistentVector{Int64}},)
 in display at multimedia.jl:152

julia> show(s)
Set{PersistentVector{Int64}}(ERROR: no method ndims(PersistentVector{Int64},)
 in show_delim_array at show.jl:124
 in show at set.jl:11
 in show at show.jl:1
```

After this patch:

``` julia
julia> a = @Persistent [1,2,3]
3-element PersistentVector{Int64}:
 1
 2
 3

julia> b = @Persistent [2,3,4]
3-element PersistentVector{Int64}:
 2
 3
 4

julia> s = Set(a,b)
Set{PersistentVector{Int64}}(Persistent{Int64}[2, 3, 4],Persistent{Int64}[1, 2, 3])
```

Note that the display of `pvecs` has changed.  It does match mainline Julia better, but if you don't like this, the alternative is to simply define `ndims`.

(Nice package, BTW!)
