### PR TITLE
Update for v0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.5
+Compat 0.17.0

--- a/src/BitmappedVectorTrie.jl
+++ b/src/BitmappedVectorTrie.jl
@@ -7,7 +7,7 @@
 const shiftby = 5
 const trielen = 2^shiftby
 
-abstract BitmappedTrie{T}
+@compat abstract type BitmappedTrie{T} end
 
 # Copy elements from one Array to another, up to `n` elements.
 #
@@ -49,7 +49,7 @@ end
 # Dense Bitmapped Tries
 # =====================
 
-abstract DenseBitmappedTrie{T} <: BitmappedTrie{T}
+@compat abstract type DenseBitmappedTrie{T} <: BitmappedTrie{T} end
 
 # Why is the shift value of a DenseLeaf 5 instead of 0, and why does
 # the shift value of a DenseNode start at 10?
@@ -77,10 +77,8 @@ end
 
 immutable DenseLeaf{T} <: DenseBitmappedTrie{T}
     arr::Vector{T}
-
-    DenseLeaf(arr::Vector) = new(arr)
-    DenseLeaf() = new(T[])
 end
+(::Type{DenseLeaf{T}}){T}() = DenseLeaf{T}(T[])
 
 arrayof(    node::DenseNode) = node.arr
 shift(      node::DenseNode) = node.shift
@@ -176,7 +174,7 @@ end
 # Sparse Bitmapped Tries
 # ======================
 
-abstract SparseBitmappedTrie{T} <: BitmappedTrie{T}
+@compat abstract type SparseBitmappedTrie{T} <: BitmappedTrie{T} end
 
 immutable SparseNode{T} <: SparseBitmappedTrie{T}
     arr::Vector{SparseBitmappedTrie{T}}
@@ -190,10 +188,8 @@ SparseNode(T::Type) = SparseNode{T}(SparseBitmappedTrie{T}[], shiftby*7, 0, trie
 immutable SparseLeaf{T} <: SparseBitmappedTrie{T}
     arr::Vector{T}
     bitmap::Int
-
-    SparseLeaf(arr::Vector, bitmap::Int) = new(arr, bitmap)
-    SparseLeaf() = new(T[], 0)
 end
+(::Type{SparseLeaf{T}}){T}() = SparseLeaf{T}(T[], 0)
 
 arrayof(    n::SparseNode) = n.arr
 shift(      n::SparseNode) = n.shift

--- a/src/PersistentList.jl
+++ b/src/PersistentList.jl
@@ -1,4 +1,4 @@
-abstract AbstractList{T}
+@compat abstract type AbstractList{T} end
 
 immutable EmptyList{T} <: AbstractList{T} end
 EmptyList() = EmptyList{Any}()
@@ -7,17 +7,15 @@ immutable PersistentList{T} <: AbstractList{T}
     head::T
     tail::AbstractList{T}
     length::Int
-    PersistentList(head::T, tail::AbstractList{T}, length) =
-        new(head, tail, length)
-    PersistentList() = EmptyList{Any}()
-    function PersistentList(v)
-        v = reverse(v)
-        list = EmptyList{T}()
-        for el in v
-            list = cons(el, list)
-        end
-        list
+end
+(::Type{PersistentList{T}}){T}() = EmptyList{Any}()
+function (::Type{PersistentList{T}}){T}(v)
+    v = reverse(v)
+    list = EmptyList{T}()
+    for el in v
+        list = cons(el, list)
     end
+    list
 end
 PersistentList(itr) = PersistentList{eltype(itr)}(itr)
 

--- a/src/PersistentMap.jl
+++ b/src/PersistentMap.jl
@@ -1,13 +1,12 @@
-abstract PersistentMap{K, V} <: Associative{K, V}
+@compat abstract type PersistentMap{K, V} <: Associative{K, V} end
 
 type NotFound end
 
 immutable PersistentArrayMap{K, V} <: PersistentMap{K, V}
     kvs::Vector{Pair{K, V}}
-
-    PersistentArrayMap(kvs::Vector{Pair{K, V}}) = new(kvs)
-    PersistentArrayMap() = new(Pair{K, V}[])
 end
+(::Type{PersistentArrayMap{K, V}}){K, V}() =
+    PersistentArrayMap{K, V}(Pair{K, V}[])
 PersistentArrayMap{K, V}(kvs::(Tuple{K, V})...) =
     PersistentArrayMap{K, V}(Pair{K, V}[Pair(k, v) for (k, v) in kvs])
 PersistentArrayMap(; kwargs...) = PersistentArrayMap(kwargs...)
@@ -72,10 +71,9 @@ Base.show{K, V}(io::IO, ::MIME"text/plain", m::PersistentArrayMap{K, V}) =
 immutable PersistentHashMap{K, V} <: PersistentMap{K, V}
     trie::SparseBitmappedTrie{PersistentArrayMap{K, V}}
     length::Int
-
-    PersistentHashMap(trie, length) = new(trie, length)
-    PersistentHashMap() = new(SparseNode(PersistentArrayMap{K, V}), 0)
 end
+(::Type{PersistentHashMap{K, V}}){K, V}() =
+    PersistentHashMap{K, V}(SparseNode(PersistentArrayMap{K, V}), 0)
 
 function PersistentHashMap(itr)
     if length(itr) == 0

--- a/src/PersistentQueue.jl
+++ b/src/PersistentQueue.jl
@@ -2,13 +2,10 @@ immutable PersistentQueue{T}
     in::AbstractList{T}
     out::AbstractList{T}
     length::Int
-
-    PersistentQueue(in::AbstractList{T}, out::AbstractList{T}, length::Int) =
-        new(in, out, length)
-
-    PersistentQueue() = new(EmptyList{T}(), EmptyList{T}(), 0)
 end
 
+(::Type{PersistentQueue{T}}){T}() =
+    PersistentQueue{T}(EmptyList{T}(), EmptyList{T}(), 0)
 PersistentQueue{T}(v::AbstractVector{T}) =
     PersistentQueue{T}(EmptyList{T}(), reverse(PersistentList(v)), length(v))
 

--- a/src/PersistentSet.jl
+++ b/src/PersistentSet.jl
@@ -1,17 +1,16 @@
 immutable PersistentSet{T}
     dict::PersistentHashMap{T, Void}
-
-    PersistentSet(d::PersistentHashMap{T, Void}) = new(d)
-    PersistentSet() = new(PersistentHashMap{T, Void}())
-    PersistentSet(itr) = _union(new(PersistentHashMap{T, Void}()), itr)
+    # TODO: this constructor is inconsistent with everything else
+    # and with Set in base; probably good to deprecate.
+    (::Type{PersistentSet{T}}){T}(d::PersistentHashMap{T, Void}) = new{T}(d)
+    (::Type{PersistentSet{T}}){T}() = new{T}(PersistentHashMap{T, Void}())
 end
+(::Type{PersistentSet{T}}){T}(itr) = _union(PersistentSet{T}(), itr)
 PersistentSet() = PersistentSet{Any}()
 PersistentSet(itr) = PersistentSet{eltype(itr)}(itr)
 
-# TODO: Depricate this invocation
-PersistentSet{T}(x1::T, x2::T, xs::T...) =
-    PersistentSet{T}(PersistentHashMap((x1, nothing), (x2, nothing),
-                                        [(x, nothing) for x in xs]...))
+Base.@deprecate(PersistentSet{T}(x1::T, x2::T, xs::T...),
+                PersistentSet{T}(T[x1, x2, xs...]))
 
 Base.hash(s::PersistentSet,h::UInt) =
     hash(s.dict, h+(UInt(0xf7dca1a5fd7090be)))

--- a/src/PersistentVector.jl
+++ b/src/PersistentVector.jl
@@ -5,16 +5,14 @@ immutable PersistentVector{T} <: AbstractArray{T,1}
     trie::DenseBitmappedTrie{Vector{T}}
     tail::Vector{T}
     length::Int
-
-    PersistentVector(trie::DenseBitmappedTrie, tail, length::Int) =
-        new(trie, tail, length)
-    PersistentVector() = new(DenseLeaf{Vector{T}}(), T[], 0)
-    function PersistentVector(arr)
-        if length(arr) <= trielen
-            new(DenseLeaf{Vector{T}}(), arr, length(arr))
-        else
-            append(new(DenseLeaf{Vector{T}}(), T[], 0), arr)
-        end
+end
+(::Type{PersistentVector{T}}){T}() =
+    PersistentVector{T}(DenseLeaf{Vector{T}}(), T[], 0)
+function (::Type{PersistentVector{T}}){T}(arr)
+    if length(arr) <= trielen
+        PersistentVector{T}(DenseLeaf{Vector{T}}(), arr, length(arr))
+    else
+        append(PersistentVector{T}(DenseLeaf{Vector{T}}(), T[], 0), arr)
     end
 end
 PersistentVector() = PersistentVector{Any}()

--- a/test/PersistentMacroTest.jl
+++ b/test/PersistentMacroTest.jl
@@ -12,7 +12,7 @@ using FunctionalCollections
     end
 
     @testset "Persistent Set" begin
-        @test @Persistent(Set(1, 2, 3, 3)) == pset(1, 2, 3, 3)
+        @test @Persistent(Set([1, 2, 3, 3])) == pset([1, 2, 3, 3])
     end
 
 end

--- a/test/PersistentMapTest.jl
+++ b/test/PersistentMapTest.jl
@@ -1,7 +1,7 @@
 using FunctionalCollections
 using Base.Test
 
-typealias PAM PersistentArrayMap
+const PAM = PersistentArrayMap
 
 @testset "Persistent Array Maps" begin
 
@@ -79,7 +79,7 @@ typealias PAM PersistentArrayMap
     end
 end
 
-typealias PHM PersistentHashMap
+const PHM = PersistentHashMap
 
 @testset "Persistent Hash Maps" begin
 

--- a/test/PersistentSetTest.jl
+++ b/test/PersistentSetTest.jl
@@ -1,12 +1,12 @@
 using Base.Test
 using FunctionalCollections
 
-typealias PS PersistentSet
+const PS = PersistentSet
 
 @testset "Persistent Sets" begin
 
     @testset "construction" begin
-        s = PS(1, 1, 2, 3, 3)
+        s = PS([1, 1, 2, 3, 3])
         @test length(s) == 3
         @test length(PS{String}()) == 0
         @test typeof(PS{Int64}([1,2,3])) == PS{Int64}
@@ -14,64 +14,64 @@ typealias PS PersistentSet
     end
 
     @testset "isequal" begin
-        @test PS(1, 2, 3) == PS(1, 2, 3)
-        @test PS(1, 2, 3) == PS(3, 2, 1)
+        @test PS([1, 2, 3]) == PS([1, 2, 3])
+        @test PS([1, 2, 3]) == PS([3, 2, 1])
         @test PS{String}() == PS{Int}()
     end
 
     @testset "conj" begin
-        @test conj(PS(1, 2, 3), 4) == PS(1, 2, 3, 4)
-        @test conj(PS(1, 2, 3), 1) == PS(1, 2, 3)
-        @test conj(PS(1, 2, 3), 4) == PS(4, 3, 2, 1)
+        @test conj(PS([1, 2, 3]), 4) == PS([1, 2, 3, 4])
+        @test conj(PS([1, 2, 3]), 1) == PS([1, 2, 3])
+        @test conj(PS([1, 2, 3]), 4) == PS([4, 3, 2, 1])
     end
 
     @testset "disj" begin
-        @test disj(PS(1, 2, 3), 3) == PS(1, 2)
-        @test disj(PS(1, 2), 3) == PS(1, 2)
+        @test disj(PS([1, 2, 3]), 3) == PS([1, 2])
+        @test disj(PS([1, 2]), 3) == PS([1, 2])
         @test disj(PS{Int}(), 1234) == PS{Int}()
     end
 
     @testset "in" begin
-        @test "foo" in PS("foo", "bar")
-        @test !("baz" in PS("foo", "bar"))
+        @test "foo" in PS(["foo", "bar"])
+        @test !("baz" in PS(["foo", "bar"]))
     end
 
     @testset "filter" begin
-        @test filter(iseven, PS(1, 2, 3, 4)) == PS(2, 4)
+        @test filter(iseven, PS([1, 2, 3, 4])) == PS([2, 4])
     end
 
     @testset "setdiff, -" begin
-        @test setdiff(PS(1, 2, 3), PS(1, 2)) == PS(3)
-        @test setdiff(PS(1, 2), PS(1, 2, 3)) == PS{Int}()
-        @test setdiff(PS(1, 2, 3), Set([1, 2])) == PS(3)
+        @test setdiff(PS([1, 2, 3]), PS([1, 2])) == PS([3])
+        @test setdiff(PS([1, 2]), PS([1, 2, 3])) == PS{Int}()
+        @test setdiff(PS([1, 2, 3]), Set([1, 2])) == PS([3])
 
-        @test PS(1, 2, 3) - PS(1, 2) == PS(3)
+        @test PS([1, 2, 3]) - PS([1, 2]) == PS([3])
     end
 
     @testset "isempty" begin
         @test isempty(PS{Int}())
-        @test !isempty(PS(1))
+        @test !isempty(PS([1]))
     end
 
     @testset "union" begin
-        @test union(PS(1, 2, 3), PS(4, 5)) == PS(1, 2, 3, 4, 5)
-        @test union(PS(1, 2, 3), PS(1, 2, 3, 4)) == PS(1, 2, 3, 4)
-        @test union(PS(1), PS(2), PS(3)) == PS(1, 2, 3)
+        @test union(PS([1, 2, 3]), PS([4, 5])) == PS([1, 2, 3, 4, 5])
+        @test union(PS([1, 2, 3]), PS([1, 2, 3, 4])) == PS([1, 2, 3, 4])
+        @test union(PS([1]), PS([2]), PS([3])) == PS([1, 2, 3])
     end
 
     @testset "isless, <=" begin
-        @test PS(1)    <= PS(1, 2)
-        @test PS(1, 2) <= PS(1, 2)
+        @test PS([1])    <= PS([1, 2])
+        @test PS([1, 2]) <= PS([1, 2])
 
-        @test !(PS(1, 2, 3) <= PS(1, 2))
-        @test PS(1, 2) <= PS(1, 2, 3)
+        @test !(PS([1, 2, 3]) <= PS([1, 2]))
+        @test PS([1, 2]) <= PS([1, 2, 3])
 
-        @test !isless(PS(1, 2), PS(1, 2))
-        @test isless(PS(1, 2), PS(1, 2, 3))
+        @test !isless(PS([1, 2]), PS([1, 2]))
+        @test isless(PS([1, 2]), PS([1, 2, 3]))
     end
 
     @testset "iteration" begin
-        @test length([el for el in PS(1, 2, 3, 4)]) == 4
+        @test length([el for el in PS([1, 2, 3, 4])]) == 4
     end
 
 end


### PR DESCRIPTION
- Fix `abstract`, `typealias` deprecation warnings
- Move many inner constructors outside to outer constructors (allowing elimination of many redundant-with-default inner constructors)
- Complete a TODO item deprecating an inconsistent `pset` constructor
- Fix the `@Persistent` macro on v0.6