### PR TITLE
implement iterator interface on plist completely

### DIFF
--- a/src/PersistentList.jl
+++ b/src/PersistentList.jl
@@ -49,8 +49,8 @@ Base.done(::AbstractList, ::EmptyList) = true
 Base.done(::AbstractList, ::PersistentList)      = false
 Base.next(::AbstractList, l::PersistentList) = (head(l), tail(l))
 
-Base.iteratorsize(::Type{AbstractList}) = Base.HasLength()
-Base.iteratoreltype(::Type{AbstractList}) = Base.HasEltype()
+Base.iteratorsize(::Type{L}) where {L<:AbstractList} = Base.HasLength()
+Base.iteratoreltype(::Type{L}) where {L<:AbstracList} = Base.HasEltype()
 Base.eltype(::Type{PersistentList{T}}) where T = T
 Base.eltype(::Type{EmptyList{T}}) where T = T
 

--- a/src/PersistentList.jl
+++ b/src/PersistentList.jl
@@ -50,7 +50,7 @@ Base.done(::AbstractList, ::PersistentList)      = false
 Base.next(::AbstractList, l::PersistentList) = (head(l), tail(l))
 
 Base.iteratorsize(::Type{L}) where {L<:AbstractList} = Base.HasLength()
-Base.iteratoreltype(::Type{L}) where {L<:AbstracList} = Base.HasEltype()
+Base.iteratoreltype(::Type{L}) where {L<:AbstractList} = Base.HasEltype()
 Base.eltype(::Type{PersistentList{T}}) where T = T
 Base.eltype(::Type{EmptyList{T}}) where T = T
 

--- a/src/PersistentList.jl
+++ b/src/PersistentList.jl
@@ -49,6 +49,11 @@ Base.done(::AbstractList, ::EmptyList) = true
 Base.done(::AbstractList, ::PersistentList)      = false
 Base.next(::AbstractList, l::PersistentList) = (head(l), tail(l))
 
+Base.iteratorsize(::Type{AbstractList}) = Base.HasLength()
+Base.iteratoreltype(::Type{AbstractList}) = Base.HasEltype()
+Base.eltype(::Type{PersistentList{T}}) where T = T
+Base.eltype(::Type{EmptyList{T}}) where T = T
+
 Base.isequal(a::AbstractArray, l::PersistentList) = isequal(l, a)
 Base.isequal(l::PersistentList, a::AbstractArray) =
     isequal(length(l), length(a)) && all((el) -> el[1] == el[2], zipd(l, a))

--- a/test/PersistentListTest.jl
+++ b/test/PersistentListTest.jl
@@ -63,4 +63,14 @@ using Base.Test
         @test !isempty(PersistentList([1]))
     end
 
+    @testset "iterator interface" begin
+        T1 = typeof(plist([1,2,3]))
+        T2 = typeof(plist(Int[]))
+        @test Base.iteratorsize(T1) == Base.HasLength()
+        @test Base.iteratorsize(T2) == Base.HasLength()
+        @test Base.iteratoreltype(T1) == Base.HasEltype()
+        @test Base.iteratoreltype(T2) == Base.HasEltype()
+        @test Base.eltype(T1) == Int
+        @test Base.eltype(T2) == Int
+    end
 end

--- a/test/PersistentListTest.jl
+++ b/test/PersistentListTest.jl
@@ -64,13 +64,19 @@ using Base.Test
     end
 
     @testset "iterator interface" begin
-        T1 = typeof(plist([1,2,3]))
-        T2 = typeof(plist(Int[]))
+        l1 = plist([1,2,3])
+        l2 = plist(Int[])
+        T1 = typeof(l1)
+        T2 = typeof(l2)
+
         @test Base.iteratorsize(T1) == Base.HasLength()
         @test Base.iteratorsize(T2) == Base.HasLength()
         @test Base.iteratoreltype(T1) == Base.HasEltype()
         @test Base.iteratoreltype(T2) == Base.HasEltype()
         @test Base.eltype(T1) == Int
         @test Base.eltype(T2) == Int
+
+        @test Base.eltype(typeof(collect(l1))) == Int
+        @test Base.eltype(typeof(collect(l2))) == Int
     end
 end


### PR DESCRIPTION
This PR adds `Base.iteratorsize`, `Base.iteratoreltype` and `Base.eltype` for `plist`. Especially the last one is important, as it allows `collect` to infer the eltype of the output array correctly.

Tests included.