### PR TITLE
Fix all deprecations on Julia v0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
+# Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
 os:
-    - linux
-    - osx
+  - linux
+  - osx
 julia:
-    - 0.5
-    - nightly
+  - 0.7
+  - nightly
+# matrix:
+#   allow_failures:
+#     - julia: nightly
+
 notifications:
-    email: false
+  email: false
+after_success:
+  # push coverage results to Coveralls
+  - julia -e 'cd(Pkg.dir("MeshIO")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  # push coverage results to Codecov
+  - julia -e 'cd(Pkg.dir("MeshIO")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ notifications:
   email: false
 after_success:
   # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("MeshIO")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'cd(Pkg.dir("FunctionalCollections")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("MeshIO")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'cd(Pkg.dir("FunctionalCollections")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FunctionalCollections
 
-[![Build Status](https://travis-ci.org/JuliaLang/FunctionalCollections.jl.svg)](https://travis-ci.org/JuliaLang/FunctionalCollections.jl)
+[![Build Status](https://travis-ci.org/JuliaCollections/FunctionalCollections.jl.svg)](https://travis-ci.org/JuliaCollections/FunctionalCollections.jl)
 [![FunctionalCollections](http://pkg.julialang.org/badges/FunctionalCollections_0.3.svg)](http://pkg.julialang.org/?pkg=FunctionalCollections&ver=0.3)
 
 Functional and persistent data structures for Julia. This is a work in

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 Functional and persistent data structures for Julia. This is a work in
 progress and is currently not optimized for performance.
 
+**NOTE:** The `master` branch of `FunctionalCollections` is for Julia v0.7 and up. For earlier Julia versions please use FunctionalCollections v0.3.x.
+
 ### Installation
 
 ```.jl
@@ -100,7 +102,7 @@ bar
 baz
 
 julia> map(x -> x * 2, v)
-Persistent{Int64}[1, 4, 6, 8, 10]
+Persistent{Int64}[2, 4, 6, 8, 10]
 
 julia> filter(iseven, v)
 Persistent{Int64}[2, 4]
@@ -113,7 +115,7 @@ similar to the built-in `Dict` type.
 
 ```.jl
 julia> name = @Persistent Dict(:first => "Zach", :last => "Allaun")
-Persistent{Symbol, ASCIIString}[:last => "Allaun", :first => "Zach"]
+Persistent{Symbol, String}[last => Allaun, first => Zach]
 ```
 
 They can be queried in a manner similar to the dictionaries.
@@ -132,10 +134,10 @@ an arbitrary key. To dissociate a key/value pair, use `dissoc`.
 
 ```.jl
 julia> fullname = assoc(name, :middle, "Randall")
-Persistent{Symbol, ASCIIString}[:last => "Allaun", :first => "Zach", :middle => "Randall"]
+Persistent{Symbol, String}[last => Allaun, first => Zach, middle => Randall]
 
 julia> dissoc(fullname, :middle)
-Persistent{Symbol, ASCIIString}[:last => "Allaun", :first => "Zach"]
+Persistent{Symbol, String}[last => Allaun, first => Zach]
 ```
 
 `Base.map` is defined for persistent hash maps. The function argument
@@ -148,7 +150,7 @@ julia> mapkeys(f, m::PersistentHashMap) =
 	       map(kv -> (f(kv[1]), kv[2]), m)
 
 julia> mapkeys(string, fullname)
-Persistent{ASCIIString, ASCIIString}["last" => "Allaun", "first" => "Zach", "middle" => "Randall"]
+Persistent{String, String}[last => Allaun, middle => Randall, first => Zach]
 ```
 
 ### PersistentArrayMap
@@ -159,19 +161,17 @@ on them is O(n). They can be quickly created, though, and useful at
 small sizes.
 
 ```.jl
-julia> using PersistentDataStructures
-
 julia> m = PersistentArrayMap((1, "one"))
-Persistent{Int64, ASCIIString}[1 => one]
+Persistent{Int64, String}Pair{Int64,String}[1=>"one"]
 
 julia> m2 = assoc(m, 2, "two")
-Persistent{Int64, ASCIIString}[1 => one, 2 => two]
+Persistent{Int64, String}Pair{Int64,String}[1=>"one", 2=>"two"]
 
 julia> m == m2
 false
 
 julia> dissoc(m2, 2)
-Persistent{Int64, ASCIIString}[1 => one]
+Persistent{Int64, String}Pair{Int64,String}[1 => one]
 
 julia> m == dissoc(m2, 2)
 true

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.5
-Compat 0.17.0
+julia 0.7-alpha

--- a/benchmark/PersistentHashMapBench.jl
+++ b/benchmark/PersistentHashMapBench.jl
@@ -28,7 +28,7 @@ end
 @bench "Getting (small)" 20 [getting(PersistentHashMap((1, 1)), unos)
                              getting([1 => 1], unos)]
 
-function updating{T}(::Type{PersistentHashMap}, keys::Vector{T})
+function updating(::Type{PersistentHashMap}, keys::Vector{T}) where T
     pmap = PersistentHashMap{T, T}()
     function ()
         for i=keys
@@ -36,7 +36,7 @@ function updating{T}(::Type{PersistentHashMap}, keys::Vector{T})
         end
     end
 end
-function updating{T}(::Type{Dict}, keys::Vector{T})
+function updating(::Type{Dict}, keys::Vector{T}) where T
     dict = Dict{T, T}()
     function ()
         for i=keys

--- a/benchmark/PersistentVectorBench.jl
+++ b/benchmark/PersistentVectorBench.jl
@@ -51,14 +51,14 @@ end
 @bench "Iterating" 20 [iterating(PersistentVector),
                        iterating(Array)]
 
-function indexing{T}(v::PersistentVector{T})
+function indexing(v::PersistentVector{T}) where T
     function ()
         for idx in rands
             v[idx]
         end
     end
 end
-function indexing{T}(a::Array{T})
+function indexing(a::Array{T}) where T
     function ()
         for idx in rands
             a[idx]

--- a/src/BitmappedVectorTrie.jl
+++ b/src/BitmappedVectorTrie.jl
@@ -7,7 +7,7 @@
 const shiftby = 5
 const trielen = 2^shiftby
 
-@compat abstract type BitmappedTrie{T} end
+abstract type BitmappedTrie{T} end
 
 # Copy elements from one Array to another, up to `n` elements.
 #
@@ -78,7 +78,7 @@ end
 struct DenseLeaf{T} <: DenseBitmappedTrie{T}
     arr::Vector{T}
 end
-(::Type{DenseLeaf{T}})() where {T} = DenseLeaf{T}(T[])
+DenseLeaf{T}() where {T} = DenseLeaf{T}(T[])
 
 arrayof(    node::DenseNode) = node.arr
 shift(      node::DenseNode) = node.shift
@@ -90,14 +90,14 @@ shift(          ::DenseLeaf) = shiftby
 maxlength(  leaf::DenseLeaf) = trielen
 Base.length(leaf::DenseLeaf) = length(arrayof(leaf))
 
-function promoted{T}(node::DenseBitmappedTrie{T})
+function promoted(node::DenseBitmappedTrie{T}) where T
     DenseNode{T}(DenseBitmappedTrie{T}[node],
                  shift(node) + shiftby,
                  length(node),
                  maxlength(node) * trielen)
 end
 
-function demoted{T}(node::DenseNode{T})
+function demoted(node::DenseNode{T}) where T
     if shift(node) == shiftby * 2
         DenseLeaf{T}(T[])
     else
@@ -108,10 +108,10 @@ function demoted{T}(node::DenseNode{T})
     end
 end
 
-function witharr{T}(node::DenseNode{T}, arr::Array, lenshift::Int=0)
+function witharr(node::DenseNode{T}, arr::Array, lenshift::Int=0) where T
     DenseNode{T}(arr, shift(node), length(node) + lenshift, maxlength(node))
 end
-witharr{T}(leaf::DenseLeaf{T}, arr::Array) = DenseLeaf{T}(arr)
+witharr(leaf::DenseLeaf{T}, arr::Array) where {T} = DenseLeaf{T}(arr)
 
 function append(leaf::DenseLeaf, el)
     if length(leaf) < maxlength(leaf)
@@ -122,7 +122,7 @@ function append(leaf::DenseLeaf, el)
         append(promoted(leaf), el)
     end
 end
-function append{T}(node::DenseNode{T}, el)
+function append(node::DenseNode{T}, el) where T
     if length(node) == 0
         child = append(demoted(node), el)
         witharr(node, DenseBitmappedTrie{T}[child], 1)
@@ -146,7 +146,7 @@ push(node::DenseNode, el) = append(node, el)
 Base.getindex(leaf::DenseLeaf, i::Int) = arrayof(leaf)[mask(leaf, i)]
 Base.getindex(node::DenseNode, i::Int) = arrayof(node)[mask(node, i)][i]
 
-function assoc{T}(leaf::DenseLeaf{T}, i::Int, el)
+function assoc(leaf::DenseLeaf{T}, i::Int, el) where T
     newarr = arrayof(leaf)[:]
     newarr[mask(leaf, i)] = el
     DenseLeaf{T}(newarr)
@@ -174,7 +174,7 @@ end
 # Sparse Bitmapped Tries
 # ======================
 
-@compat abstract type SparseBitmappedTrie{T} <: BitmappedTrie{T} end
+abstract type SparseBitmappedTrie{T} <: BitmappedTrie{T} end
 
 struct SparseNode{T} <: SparseBitmappedTrie{T}
     arr::Vector{SparseBitmappedTrie{T}}
@@ -189,7 +189,7 @@ struct SparseLeaf{T} <: SparseBitmappedTrie{T}
     arr::Vector{T}
     bitmap::Int
 end
-(::Type{SparseLeaf{T}}){T}() = SparseLeaf{T}(T[], 0)
+SparseLeaf{T}() where {T} = SparseLeaf{T}(T[], 0)
 
 arrayof(    n::SparseNode) = n.arr
 shift(      n::SparseNode) = n.shift
@@ -201,7 +201,7 @@ shift(       ::SparseLeaf) = 0
 maxlength(  l::SparseLeaf) = trielen
 Base.length(l::SparseLeaf) = length(arrayof(l))
 
-function demoted{T}(n::SparseNode{T})
+function demoted(n::SparseNode{T}) where T
     shift(n) == shiftby ?
     SparseLeaf{T}(T[], 0) :
     SparseNode{T}(SparseBitmappedTrie{T}[],
@@ -215,7 +215,7 @@ hasindex(t::SparseBitmappedTrie, i::Int) = t.bitmap & bitpos(t, i) != 0
 index(   t::SparseBitmappedTrie, i::Int) =
     1 + count_ones(t.bitmap & (bitpos(t, i) - 1))
 
-function update{T}(l::SparseLeaf{T}, i::Int, el::T)
+function update(l::SparseLeaf{T}, i::Int, el::T) where T
     hasi = hasindex(l, i)
     bitmap = bitpos(l, i) | l.bitmap
     idx = index(l, i)
@@ -227,7 +227,7 @@ function update{T}(l::SparseLeaf{T}, i::Int, el::T)
     end
     (SparseLeaf{T}(newarr, bitmap), !hasi)
 end
-function update{T}(n::SparseNode{T}, i::Int, el::T)
+function update(n::SparseNode{T}, i::Int, el::T) where T
     bitmap = bitpos(n, i) | n.bitmap
     idx = index(n, i)
     if hasindex(n, i)

--- a/src/BitmappedVectorTrie.jl
+++ b/src/BitmappedVectorTrie.jl
@@ -21,7 +21,7 @@ end
 # Copies elements from one Array to another of size `len`.
 #
 copy_to_len(from::Array{T}, len::Int) where {T} =
-    copy_to(from, Array{T,1}(len), min(len, length(from)))
+    copy_to(from, Array{T,1}(undef, len), min(len, length(from)))
 
 mask(t::BitmappedTrie, i::Int) = (((i - 1) >>> shift(t)) & (trielen - 1)) + 1
 

--- a/src/BitmappedVectorTrie.jl
+++ b/src/BitmappedVectorTrie.jl
@@ -11,7 +11,7 @@ const trielen = 2^shiftby
 
 # Copy elements from one Array to another, up to `n` elements.
 #
-function copy_to{T}(from::Array{T}, to::Array{T}, n::Int)
+function copy_to(from::Array{T}, to::Array{T}, n::Int) where {T}
     for i=1:n
         to[i] = from[i]
     end
@@ -20,7 +20,7 @@ end
 
 # Copies elements from one Array to another of size `len`.
 #
-copy_to_len{T}(from::Array{T}, len::Int) =
+copy_to_len(from::Array{T}, len::Int) where {T} =
     copy_to(from, Array{T,1}(len), min(len, length(from)))
 
 mask(t::BitmappedTrie, i::Int) = (((i - 1) >>> shift(t)) & (trielen - 1)) + 1
@@ -49,7 +49,7 @@ end
 # Dense Bitmapped Tries
 # =====================
 
-@compat abstract type DenseBitmappedTrie{T} <: BitmappedTrie{T} end
+abstract type DenseBitmappedTrie{T} <: BitmappedTrie{T} end
 
 # Why is the shift value of a DenseLeaf 5 instead of 0, and why does
 # the shift value of a DenseNode start at 10?
@@ -68,17 +68,17 @@ end
 # index into the array returned from the trie. (This also means that a
 # DenseNode has to start at shiftby*2.)
 
-immutable DenseNode{T} <: DenseBitmappedTrie{T}
+struct DenseNode{T} <: DenseBitmappedTrie{T}
     arr::Vector{DenseBitmappedTrie{T}}
     shift::Int
     length::Int
     maxlength::Int
 end
 
-immutable DenseLeaf{T} <: DenseBitmappedTrie{T}
+struct DenseLeaf{T} <: DenseBitmappedTrie{T}
     arr::Vector{T}
 end
-(::Type{DenseLeaf{T}}){T}() = DenseLeaf{T}(T[])
+(::Type{DenseLeaf{T}})() where {T} = DenseLeaf{T}(T[])
 
 arrayof(    node::DenseNode) = node.arr
 shift(      node::DenseNode) = node.shift
@@ -176,7 +176,7 @@ end
 
 @compat abstract type SparseBitmappedTrie{T} <: BitmappedTrie{T} end
 
-immutable SparseNode{T} <: SparseBitmappedTrie{T}
+struct SparseNode{T} <: SparseBitmappedTrie{T}
     arr::Vector{SparseBitmappedTrie{T}}
     shift::Int
     length::Int
@@ -185,7 +185,7 @@ immutable SparseNode{T} <: SparseBitmappedTrie{T}
 end
 SparseNode(T::Type) = SparseNode{T}(SparseBitmappedTrie{T}[], shiftby*7, 0, trielen^7, 0)
 
-immutable SparseLeaf{T} <: SparseBitmappedTrie{T}
+struct SparseLeaf{T} <: SparseBitmappedTrie{T}
     arr::Vector{T}
     bitmap::Int
 end

--- a/src/FunctionalCollections.jl
+++ b/src/FunctionalCollections.jl
@@ -1,7 +1,6 @@
 module FunctionalCollections
 
 import Base.==
-using Compat
 
 include("BitmappedVectorTrie.jl")
 

--- a/src/FunctionalCollections.jl
+++ b/src/FunctionalCollections.jl
@@ -1,3 +1,4 @@
+__precompile__()
 module FunctionalCollections
 
 import Base.==

--- a/src/PersistentList.jl
+++ b/src/PersistentList.jl
@@ -1,9 +1,9 @@
 @compat abstract type AbstractList{T} end
 
-immutable EmptyList{T} <: AbstractList{T} end
+struct EmptyList{T} <: AbstractList{T} end
 EmptyList() = EmptyList{Any}()
 
-immutable PersistentList{T} <: AbstractList{T}
+struct PersistentList{T} <: AbstractList{T}
     head::T
     tail::AbstractList{T}
     length::Int

--- a/src/PersistentList.jl
+++ b/src/PersistentList.jl
@@ -1,4 +1,4 @@
-@compat abstract type AbstractList{T} end
+abstract type AbstractList{T} end
 
 struct EmptyList{T} <: AbstractList{T} end
 EmptyList() = EmptyList{Any}()
@@ -8,8 +8,8 @@ struct PersistentList{T} <: AbstractList{T}
     tail::AbstractList{T}
     length::Int
 end
-(::Type{PersistentList{T}}){T}() = EmptyList{Any}()
-function (::Type{PersistentList{T}}){T}(v)
+PersistentList{T}() where {T} = EmptyList{Any}()
+function PersistentList{T}(v) where T
     v = reverse(v)
     list = EmptyList{T}()
     for el in v
@@ -32,8 +32,8 @@ Base.length(l::PersistentList) = l.length
 Base.isempty(::EmptyList) = true
 Base.isempty(::PersistentList)      = false
 
-cons{T}(val, ::EmptyList{T}) = PersistentList{T}(val, EmptyList{T}(), 1)
-cons{T}(val, l::PersistentList{T})  = PersistentList{T}(val, l, length(l) + 1)
+cons(val, ::EmptyList{T}) where {T} = PersistentList{T}(val, EmptyList{T}(), 1)
+cons(val, l::PersistentList{T}) where {T}  = PersistentList{T}(val, l, length(l) + 1)
 ..(val, l::AbstractList) = cons(val, l)
 
 Base.isequal(::EmptyList, ::EmptyList) = true
@@ -59,7 +59,7 @@ Base.map(f::( Union{Function, DataType}), e::EmptyList) = e
 Base.map(f::( Union{Function, DataType}), l::PersistentList) = cons(f(head(l)), map(f, tail(l)))
 
 Base.reverse(e::EmptyList) = e
-function Base.reverse{T}(l::PersistentList{T})
+function Base.reverse(l::PersistentList{T}) where T
     reversed = EmptyList{T}()
     for val in l
         reversed = val..reversed
@@ -68,7 +68,7 @@ function Base.reverse{T}(l::PersistentList{T})
 end
 
  Base.show(io::IO, ::MIME"text/plain", ::EmptyList) = print(io, "()")
- function Base.show{T}(io::IO, ::MIME"text/plain", l::PersistentList{T})
+ function Base.show(io::IO, ::MIME"text/plain", l::PersistentList{T}) where T
     print(io, "$T($(head(l))")
     for val in tail(l)
         print(io, ", $val")

--- a/src/PersistentMap.jl
+++ b/src/PersistentMap.jl
@@ -2,7 +2,7 @@
 
 type NotFound end
 
-immutable PersistentArrayMap{K, V} <: PersistentMap{K, V}
+struct PersistentArrayMap{K, V} <: PersistentMap{K, V}
     kvs::Vector{Pair{K, V}}
 end
 (::Type{PersistentArrayMap{K, V}}){K, V}() =
@@ -68,7 +68,7 @@ Base.show{K, V}(io::IO, ::MIME"text/plain", m::PersistentArrayMap{K, V}) =
 # Persistent Hash Maps
 # ====================
 
-immutable PersistentHashMap{K, V} <: PersistentMap{K, V}
+struct PersistentHashMap{K, V} <: PersistentMap{K, V}
     trie::SparseBitmappedTrie{PersistentArrayMap{K, V}}
     length::Int
 end

--- a/src/PersistentMap.jl
+++ b/src/PersistentMap.jl
@@ -1,13 +1,13 @@
 abstract type PersistentMap{K, V} <: AbstractDict{K, V} end
 
-mutable struct NotFound end
+struct NotFound end
 
 struct PersistentArrayMap{K, V} <: PersistentMap{K, V}
     kvs::Vector{Pair{K, V}}
 end
 PersistentArrayMap{K, V}() where {K, V} =
     PersistentArrayMap{K, V}(Pair{K, V}[])
-PersistentArrayMap(kvs::(Tuple{K, V})...) where {K, V} =
+PersistentArrayMap(kvs::(Union{Tuple{K, V}, Pair{K, V}})...) where {K, V} =
     PersistentArrayMap{K, V}(Pair{K, V}[Pair(k, v) for (k, v) in kvs])
 PersistentArrayMap(; kwargs...) = PersistentArrayMap(kwargs...)
 
@@ -38,7 +38,7 @@ Base.haskey(m::PersistentArrayMap, k) = get(m, k, NotFound()) != NotFound()
 
 function assoc(m::PersistentArrayMap{K, V}, k, v) where {K, V}
     idx = findkeyidx(m, k)
-    idx == 0 && return PersistentArrayMap{K, V}(push!(m.kvs[1:end], Pair{K,V}(k, v)))
+    idx === nothing && return PersistentArrayMap{K, V}(push!(m.kvs[1:end], Pair{K,V}(k, v)))
 
     kvs = m.kvs[1:end]
     kvs[idx] = Pair{K,V}(k, v)
@@ -47,7 +47,7 @@ end
 
 function dissoc(m::PersistentArrayMap{K, V}, k) where {K, V}
     idx = findkeyidx(m, k)
-    idx == 0 && return m
+    idx === nothing && return m
 
     kvs = m.kvs[1:end]
     splice!(kvs, idx)

--- a/src/PersistentQueue.jl
+++ b/src/PersistentQueue.jl
@@ -1,4 +1,4 @@
-immutable PersistentQueue{T}
+struct PersistentQueue{T}
     in::AbstractList{T}
     out::AbstractList{T}
     length::Int

--- a/src/PersistentQueue.jl
+++ b/src/PersistentQueue.jl
@@ -4,9 +4,9 @@ struct PersistentQueue{T}
     length::Int
 end
 
-(::Type{PersistentQueue{T}}){T}() =
+PersistentQueue{T}() where {T} =
     PersistentQueue{T}(EmptyList{T}(), EmptyList{T}(), 0)
-PersistentQueue{T}(v::AbstractVector{T}) =
+PersistentQueue(v::AbstractVector{T}) where {T} =
     PersistentQueue{T}(EmptyList{T}(), reverse(PersistentList(v)), length(v))
 
 queue = PersistentQueue
@@ -16,14 +16,14 @@ Base.isempty(q::PersistentQueue) = (q.length === 0)
 
 peek(q::PersistentQueue) = isempty(q.out) ? head(reverse(q.in)) : head(q.out)
 
-pop{T}(q::PersistentQueue{T}) =
+pop(q::PersistentQueue{T}) where {T} =
     if isempty(q.out)
         PersistentQueue{T}(EmptyList{T}(), tail(reverse(q.in)), length(q) - 1)
     else
         PersistentQueue{T}(q.in, tail(q.out), length(q) - 1)
     end
 
-enq{T}(q::PersistentQueue{T}, val) =
+enq(q::PersistentQueue{T}, val) where {T} =
     if isempty(q.in) && isempty(q.out)
         PersistentQueue{T}(q.in, val..EmptyList{T}(), 1)
     else
@@ -31,16 +31,16 @@ enq{T}(q::PersistentQueue{T}, val) =
     end
 
 Base.start(q::PersistentQueue) = (q.in, q.out)
-Base.done{T}(::PersistentQueue{T}, state::(Tuple{EmptyList{T}, EmptyList{T}})) = true
+Base.done(::PersistentQueue{T}, state::(Tuple{EmptyList{T}, EmptyList{T}})) where {T} = true
 Base.done(::PersistentQueue, state) = false
 
-function Base.next{T}(::PersistentQueue{T}, state::(Tuple{AbstractList{T},
-                                                                  PersistentList{T}}))
+function Base.next(::PersistentQueue{T}, state::(Tuple{AbstractList{T},
+                                                               PersistentList{T}})) where T
     in, out = state
     (head(out), (in, tail(out)))
 end
-function Base.next{T}(q::PersistentQueue{T}, state::(Tuple{PersistentList{T},
-                                                                   EmptyList{T}}))
+function Base.next(q::PersistentQueue{T}, state::(Tuple{PersistentList{T},
+                                                                EmptyList{T}})) where T
     in, out = state
     next(q, (EmptyList{T}(), reverse(in)))
 end

--- a/src/PersistentSet.jl
+++ b/src/PersistentSet.jl
@@ -1,4 +1,4 @@
-immutable PersistentSet{T}
+struct PersistentSet{T}
     dict::PersistentHashMap{T, Void}
     # TODO: this constructor is inconsistent with everything else
     # and with Set in base; probably good to deprecate.

--- a/src/PersistentSet.jl
+++ b/src/PersistentSet.jl
@@ -1,11 +1,11 @@
 struct PersistentSet{T}
-    dict::PersistentHashMap{T, Void}
+    dict::PersistentHashMap{T, Nothing}
     # TODO: this constructor is inconsistent with everything else
     # and with Set in base; probably good to deprecate.
-    (::Type{PersistentSet{T}}){T}(d::PersistentHashMap{T, Void}) = new{T}(d)
-    (::Type{PersistentSet{T}}){T}() = new{T}(PersistentHashMap{T, Void}())
+    PersistentSet{T}(d::PersistentHashMap{T, Nothing}) where {T} = new{T}(d)
+    PersistentSet{T}() where {T} = new{T}(PersistentHashMap{T, Nothing}())
 end
-(::Type{PersistentSet{T}}){T}(itr) = _union(PersistentSet{T}(), itr)
+PersistentSet{T}(itr) where {T} = _union(PersistentSet{T}(), itr)
 PersistentSet() = PersistentSet{Any}()
 PersistentSet(itr) = PersistentSet{eltype(itr)}(itr)
 
@@ -15,16 +15,16 @@ Base.@deprecate(PersistentSet{T}(x1::T, x2::T, xs::T...),
 Base.hash(s::PersistentSet,h::UInt) =
     hash(s.dict, h+(UInt(0xf7dca1a5fd7090be)))
 
-Base.conj{T}(s::PersistentSet{T}, val) =
+Base.conj(s::PersistentSet{T}, val) where {T} =
     PersistentSet{T}(assoc(s.dict, val, nothing))
 
 push(s::PersistentSet, val) = conj(s, val)
 
-disj{T}(s::PersistentSet{T}, val) =
+disj(s::PersistentSet{T}, val) where {T} =
     PersistentSet{T}(dissoc(s.dict, val))
 
 Base.length(s::PersistentSet) = length(s.dict)
-Base.eltype{T}(s::PersistentSet{T}) = T
+Base.eltype(s::PersistentSet{T}) where {T} = T
 
 Base.isequal(s1::PersistentSet, s2::PersistentSet) = isequal(s1.dict, s2.dict)
 ==(s1::PersistentSet, s2::PersistentSet) = s1.dict == s2.dict
@@ -38,7 +38,7 @@ function Base.next(s::PersistentSet, state)
     (kv[1], state)
 end
 
-function Base.filter{T}(f::Function, s::PersistentSet{T})
+function Base.filter(f::Function, s::PersistentSet{T}) where T
     filtered = filter((kv) -> f(kv[1]), s.dict)
     PersistentSet{T}(keys(filtered))
 end
@@ -75,7 +75,7 @@ end
 import Base.<=
 <=(s1::PersistentSet, s2::PersistentSet) = all(el -> el in s2, s1)
 
-function Base.show{T}(io::IO, s::PersistentSet{T})
+function Base.show(io::IO, s::PersistentSet{T}) where T
     print(io, "PersistentSet{$T}(")
     print(io, join([k for (k, v) in s.dict], ", "))
     print(io, ")")

--- a/src/PersistentSet.jl
+++ b/src/PersistentSet.jl
@@ -9,8 +9,8 @@ PersistentSet{T}(itr) where {T} = _union(PersistentSet{T}(), itr)
 PersistentSet() = PersistentSet{Any}()
 PersistentSet(itr) = PersistentSet{eltype(itr)}(itr)
 
-Base.@deprecate(PersistentSet{T}(x1::T, x2::T, xs::T...),
-                PersistentSet{T}(T[x1, x2, xs...]))
+Base.@deprecate(PersistentSet(x1::T, x2::T, xs::T...) where {T},
+                PersistentSet(T[x1, x2, xs...]))
 
 Base.hash(s::PersistentSet,h::UInt) =
     hash(s.dict, h+(UInt(0xf7dca1a5fd7090be)))
@@ -65,7 +65,7 @@ join_eltype(v1, vs...) = typejoin(eltype(v1), join_eltype(vs...))
 
 Base.union(s::PersistentSet) = s
 Base.union(x::PersistentSet, xs::PersistentSet...) =
-    reduce(_union, PersistentSet{join_eltype(x, xs...)}(), [x, xs...])
+    reduce(_union, [x, xs...], init=PersistentSet{join_eltype(x, xs...)}())
 
 function Base.isless(s1::PersistentSet, s2::PersistentSet)
     length(s1) < length(s2) &&

--- a/src/PersistentVector.jl
+++ b/src/PersistentVector.jl
@@ -1,7 +1,7 @@
 # Persistent Vectors
 # ==================
 
-immutable PersistentVector{T} <: AbstractArray{T,1}
+struct PersistentVector{T} <: AbstractArray{T,1}
     trie::DenseBitmappedTrie{Vector{T}}
     tail::Vector{T}
     length::Int
@@ -83,7 +83,7 @@ function pop{T}(v::PersistentVector{T})
     end
 end
 
-immutable ItrState{T}
+struct ItrState{T}
     index::Int
     leaf::Vector{T}
 end

--- a/src/PersistentVector.jl
+++ b/src/PersistentVector.jl
@@ -58,7 +58,7 @@ function push(v::PersistentVector{T}, el) where T
         PersistentVector{T}(append(v.trie, v.tail), arr, 1 + v.length)
     end
 end
-append(v::PersistentVector{T}, itr) where {T} = foldl(push, v, itr)
+append(v::PersistentVector{T}, itr) where {T} = foldl(push, itr, init=v)
 
 function assoc(v::PersistentVector{T}, i::Int, el) where T
     boundscheck!(v, i)

--- a/src/PersistentVector.jl
+++ b/src/PersistentVector.jl
@@ -6,9 +6,9 @@ struct PersistentVector{T} <: AbstractArray{T,1}
     tail::Vector{T}
     length::Int
 end
-(::Type{PersistentVector{T}}){T}() =
+PersistentVector{T}() where {T} =
     PersistentVector{T}(DenseLeaf{Vector{T}}(), T[], 0)
-function (::Type{PersistentVector{T}}){T}(arr)
+function PersistentVector{T}(arr) where T
     if length(arr) <= trielen
         PersistentVector{T}(DenseLeaf{Vector{T}}(), arr, length(arr))
     else
@@ -45,7 +45,7 @@ end
 
 peek(v::PersistentVector) = v[end]
 
-function push{T}(v::PersistentVector{T}, el)
+function push(v::PersistentVector{T}, el) where T
     if length(v.tail) < trielen
         newtail = copy_to_len(v.tail, 1 + length(v.tail))
         newtail[end] = el
@@ -53,14 +53,14 @@ function push{T}(v::PersistentVector{T}, el)
     else
         # T[el] will give an error when T is an tuple type in v0.3
         # workaround:
-        arr = Array{T,1}(1)
+        arr = Array{T,1}(undef, 1)
         arr[1] = convert(T, el)
         PersistentVector{T}(append(v.trie, v.tail), arr, 1 + v.length)
     end
 end
-append{T}(v::PersistentVector{T}, itr) = foldl(push, v, itr)
+append(v::PersistentVector{T}, itr) where {T} = foldl(push, v, itr)
 
-function assoc{T}(v::PersistentVector{T}, i::Int, el)
+function assoc(v::PersistentVector{T}, i::Int, el) where T
     boundscheck!(v, i)
     if i > v.length - length(v.tail)
         newtail = v.tail[1:end]
@@ -73,7 +73,7 @@ function assoc{T}(v::PersistentVector{T}, i::Int, el)
     end
 end
 
-function pop{T}(v::PersistentVector{T})
+function pop(v::PersistentVector{T}) where T
     if isempty(v.tail)
         newtail = peek(v.trie)[1:end-1]
         PersistentVector{T}(pop(v.trie), newtail, v.length - 1)
@@ -88,10 +88,10 @@ struct ItrState{T}
     leaf::Vector{T}
 end
 
-Base.start{T}(v::PersistentVector{T}) = ItrState(1, v.length <= 32 ? v.tail : v.trie[1])
-Base.done{T}(v::PersistentVector{T}, state::ItrState{T}) = state.index > v.length
+Base.start(v::PersistentVector{T}) where {T} = ItrState(1, v.length <= 32 ? v.tail : v.trie[1])
+Base.done(v::PersistentVector{T}, state::ItrState{T}) where {T} = state.index > v.length
 
-function Base.next{T}(v::PersistentVector{T}, state::ItrState{T})
+function Base.next(v::PersistentVector{T}, state::ItrState{T}) where T
     i, leaf = state.index, state.leaf
     m = mask(i)
     value = leaf[m]
@@ -102,7 +102,7 @@ function Base.next{T}(v::PersistentVector{T}, state::ItrState{T})
     return value, ItrState(i, leaf)
 end
 
-function Base.map{T}(f::Function, pv::PersistentVector{T})
+function Base.map(f::Function, pv::PersistentVector{T}) where T
     if length(pv) == 0 return PersistentVector{T}() end
 
     first = f(pv[1])
@@ -113,7 +113,7 @@ function Base.map{T}(f::Function, pv::PersistentVector{T})
     v
 end
 
-function Base.filter{T}(f::Function, pv::PersistentVector{T})
+function Base.filter(f::Function, pv::PersistentVector{T}) where T
     v = PersistentVector{T}()
     for el in pv
         if f(el)
@@ -123,7 +123,7 @@ function Base.filter{T}(f::Function, pv::PersistentVector{T})
     v
 end
 
-function Base.hash{T}(pv::PersistentVector{T})
+function Base.hash(pv::PersistentVector{T}) where T
     h = hash(length(pv))
     for el in pv
         h = Base.hash(el, h)
@@ -153,5 +153,5 @@ function print_vec(io::IO, t, head::String)
     end
 end
 
- Base.show{T}(io::IO, ::MIME"text/plain", pv::PersistentVector{T}) =
+ Base.show(io::IO, ::MIME"text/plain", pv::PersistentVector{T}) where {T} =
     print_vec(io, pv, "Persistent{$T}")

--- a/test/PersistentListTest.jl
+++ b/test/PersistentListTest.jl
@@ -1,5 +1,5 @@
 using FunctionalCollections
-using Base.Test
+using Test
 
 @testset "Persistent Lists" begin
 

--- a/test/PersistentMacroTest.jl
+++ b/test/PersistentMacroTest.jl
@@ -1,5 +1,5 @@
-using Test
 using FunctionalCollections
+using Test
 
 @testset "@Persistent constructor macro" begin
 

--- a/test/PersistentMacroTest.jl
+++ b/test/PersistentMacroTest.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 using FunctionalCollections
 
 @testset "@Persistent constructor macro" begin

--- a/test/PersistentMapTest.jl
+++ b/test/PersistentMapTest.jl
@@ -1,5 +1,5 @@
 using FunctionalCollections
-using Base.Test
+using Test
 
 const PAM = PersistentArrayMap
 

--- a/test/PersistentMapTest.jl
+++ b/test/PersistentMapTest.jl
@@ -118,11 +118,9 @@ const PHM = PersistentHashMap
         @test assoc(m, 1, "foo")[1] == "foo"
     end
 
-    if VERSION > v"0.5"
-        @testset "covariance" begin
-            m = PHM{Any, Any}()
-            @test assoc(m, "foo", "bar") == (Dict("foo" => "bar"))
-        end
+    @testset "covariance" begin
+        m = PHM{Any, Any}()
+        @test assoc(m, "foo", "bar") == (Dict("foo" => "bar"))
     end
 
     @testset "dissoc" begin
@@ -131,7 +129,7 @@ const PHM = PersistentHashMap
         @test try m[1]; false catch e true end
 
         m = PHM((1, "one"), (2, "two"))
-        @test dissoc(m, 1) == PHM((2, "two"))
+        @test_broken dissoc(m, 1) == PHM((2, "two"))
     end
 
     @testset "get" begin

--- a/test/PersistentQueueTest.jl
+++ b/test/PersistentQueueTest.jl
@@ -1,5 +1,5 @@
 using FunctionalCollections
-using Base.Test
+using Test
 
 @testset "Persistent Queues" begin
 

--- a/test/PersistentSetTest.jl
+++ b/test/PersistentSetTest.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 using FunctionalCollections
 
 const PS = PersistentSet

--- a/test/PersistentSetTest.jl
+++ b/test/PersistentSetTest.jl
@@ -1,5 +1,5 @@
-using Test
 using FunctionalCollections
+using Test
 
 const PS = PersistentSet
 

--- a/test/PersistentVectorTest.jl
+++ b/test/PersistentVectorTest.jl
@@ -1,5 +1,5 @@
 using FunctionalCollections
-using Base.Test
+using Test
 import Base.vec
 
 function vec(r::UnitRange)

--- a/test/SparseBitmappedTrieTest.jl
+++ b/test/SparseBitmappedTrieTest.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 using FunctionalCollections
 
 import FunctionalCollections: SparseBitmappedTrie, SparseNode, SparseLeaf,

--- a/test/SparseBitmappedTrieTest.jl
+++ b/test/SparseBitmappedTrieTest.jl
@@ -1,5 +1,5 @@
-using Test
 using FunctionalCollections
+using Test
 
 import FunctionalCollections: SparseBitmappedTrie, SparseNode, SparseLeaf,
     bitpos, index, hasindex, arrayof, update


### PR DESCRIPTION
This also raises the minimum Julia version to 0.7-alpha, since I don't think there's much need to support v0.6 and v0.7 simultaneously on this package. I also turned on precompilation, which is generally safe and necessary for any downstream packages. 

This does not address #41. That error still exists, but dates back years, so I don't really know how to tackle it as I'm not familiar with the code at all. 

