### PR TITLE
Fix haskey for PersistentHashMap

### DIFF
--- a/src/PersistentMap.jl
+++ b/src/PersistentMap.jl
@@ -153,7 +153,8 @@ function Base.get(m::PersistentHashMap, key, default)
 end
 
 function Base.haskey(m::PersistentHashMap, key)
-    get(m.trie, reinterpret(Int, hash(key)), NotFound()) != NotFound()
+    val = get(m.trie, reinterpret(Int, hash(key)), NotFound())
+    (val != NotFound()) && haskey(val, key)
 end
 
 function Base.iterate(m::PersistentHashMap)

--- a/test/PersistentMapTest.jl
+++ b/test/PersistentMapTest.jl
@@ -150,6 +150,13 @@ const PHM = PersistentHashMap
         @test !haskey(m, 2)
     end
 
+    @testset "haskey dissoc" begin
+        m = PHM{Int, String}()
+        m = assoc(m, 1, "one")
+        m = dissoc(m, 1)
+        @test !haskey(m, 1)
+    end
+
     @testset "map" begin
         m = PHM((1, 1), (2, 2), (3, 3))
         @test map((kv) -> (kv[1], kv[2]+1), m) == PHM((1, 2), (2, 3), (3, 4))


### PR DESCRIPTION
Fixes bug in `haskey` for `PersistentHashMap`, which is exercised by the example below, and adds a test for it.

```
using FunctionalCollections
m = PersistentHashMap{Int, String}()
m = assoc(m, 1, "one")
m = dissoc(m, 1)
@assert !haskey(m, 1)
```