### PR TITLE
Add identity constructor for PersistentVector

### DIFF
--- a/src/PersistentVector.jl
+++ b/src/PersistentVector.jl
@@ -15,6 +15,7 @@ function PersistentVector{T}(arr) where T
         append(PersistentVector{T}(DenseLeaf{Vector{T}}(), T[], 0), arr)
     end
 end
+PersistentVector{T}(v::PersistentVector{T}) where {T} = v
 PersistentVector() = PersistentVector{Any}()
 PersistentVector(itr) = PersistentVector{eltype(itr)}(itr)
 

--- a/src/PersistentVector.jl
+++ b/src/PersistentVector.jl
@@ -15,9 +15,15 @@ function PersistentVector{T}(arr) where T
         append(PersistentVector{T}(DenseLeaf{Vector{T}}(), T[], 0), arr)
     end
 end
+PersistentVector(v::PersistentVector) = v
 PersistentVector{T}(v::PersistentVector{T}) where {T} = v
 PersistentVector() = PersistentVector{Any}()
 PersistentVector(itr) = PersistentVector{eltype(itr)}(itr)
+
+Base.convert(::Type{PersistentVector}, x) = PersistentVector(x)
+Base.convert(::Type{PersistentVector{T}}, x) where {T} = PersistentVector{T}(x)
+Base.convert(::Type{PersistentVector}, x::PersistentVector{T}) where {T} = x
+Base.convert(::Type{PersistentVector{T}}, x::PersistentVector{T}) where {T} = x
 
 mask(i::Int) = ((i - 1) & (trielen - 1)) + 1
 

--- a/test/PersistentVectorTest.jl
+++ b/test/PersistentVectorTest.jl
@@ -111,4 +111,9 @@ end
         @test !isempty(PersistentVector([1]))
     end
 
+    @testset "identity constructor" begin
+        pv = vec(1:10)
+        @test pv === PersistentVector(pv)
+    end
+
 end

--- a/test/PersistentVectorTest.jl
+++ b/test/PersistentVectorTest.jl
@@ -114,6 +114,22 @@ end
     @testset "identity constructor" begin
         pv = vec(1:10)
         @test pv === PersistentVector(pv)
+        @test pv === PersistentVector{Int}(pv)
+        @test typeof(PersistentVector{Any}(pv)) == PersistentVector{Any}
+    end
+
+    @testset "convert" begin
+        @test convert(PersistentVector, [1, 2, 3]) == PersistentVector([1, 2, 3])
+        @test convert(PersistentVector{Int}, [1, 2, 3]) == PersistentVector([1, 2, 3])
+
+        @test typeof(convert(PersistentVector{Any}, [1, 2, 3])) == PersistentVector{Any}
+        @test convert(PersistentVector{Float64}, [1, 2, 3]) == [1.0, 2.0, 3.0]
+
+        # Test identity conversion
+        pv = vec(1:10)
+        @test convert(PersistentVector, pv) === pv
+        @test convert(PersistentVector{Int}, pv) === pv
+        @test typeof(convert(PersistentVector{Float64}, pv)) == PersistentVector{Float64}
     end
 
 end


### PR DESCRIPTION
This is useful in scenarios where you want to ensure something is a `PersistentVector` but don't want to copy it if it already is. We use this in [WebIO.jl](https://github.com/JuliaGizmos/WebIO.jl) and currently create our own `_pvec` function that implements this logic.