### PR TITLE
Fix bug in pvec `pop` resulting in empty tail

### DIFF
--- a/src/PersistentVector.jl
+++ b/src/PersistentVector.jl
@@ -81,7 +81,11 @@ function assoc(v::PersistentVector{T}, i::Int, el) where T
 end
 
 function pop(v::PersistentVector{T}) where T
-    if isempty(v.tail)
+    taillen = length(v.tail)
+    if taillen == 1
+        newtail = peek(v.trie)
+        PersistentVector{T}(pop(v.trie), newtail, v.length - 1)
+    elseif taillen == 0
         newtail = peek(v.trie)[1:end-1]
         PersistentVector{T}(pop(v.trie), newtail, v.length - 1)
     else

--- a/src/PersistentVector.jl
+++ b/src/PersistentVector.jl
@@ -81,6 +81,9 @@ function assoc(v::PersistentVector{T}, i::Int, el) where T
 end
 
 function pop(v::PersistentVector{T}) where T
+    if length(v) == 1
+        return PersistentVector{T}()
+    end
     taillen = length(v.tail)
     if taillen == 1
         newtail = peek(v.trie)

--- a/test/PersistentVectorTest.jl
+++ b/test/PersistentVectorTest.jl
@@ -131,5 +131,10 @@ end
         @test convert(PersistentVector{Int}, pv) === pv
         @test typeof(convert(PersistentVector{Float64}, pv)) == PersistentVector{Float64}
     end
+    
+    @testset "pop" begin
+        p = pvec(1:33)
+        @test length(pop(p).tail) == 32
+    end
 
 end

--- a/test/PersistentVectorTest.jl
+++ b/test/PersistentVectorTest.jl
@@ -135,6 +135,12 @@ end
     @testset "pop" begin
         p = pvec(1:33)
         @test length(pop(p).tail) == 32
+        
+        p = pvec(1:100)
+        for _=1:100
+            p = pop(p)
+        end
+        @test p == pvec{Int}()
     end
 
 end


### PR DESCRIPTION
When calling `pop` on a persistent vector with, eg., 33 elements, we have a `tail` of length 1.  After this `pop` call, there was a bug where the resulting pvec had a tail of length `0` rather than a tail of length `32`.  This causes errors, for instance when calling `iterate`, which expects a nonempty tail.  This PR fixes the behavior by adding a branch in `pop` function for when the tail length is currently `1` (in which case we make the new tail be `pop(trie)`).