### PR TITLE
Added Persistent disjoint set implementation.

### DIFF
--- a/src/PersistentDisjointSet.jl
+++ b/src/PersistentDisjointSet.jl
@@ -1,0 +1,32 @@
+struct PersistentDisjointSet{T}
+    table::PersistentHashMap{T,T}
+    heights::PersistentHashMap{T,UInt8}
+end
+PersistentDisjointSet{T}() where {T} = PersistentDisjointSet{T}(PersistentHashMap{T,T}(),PersistentHashMap{T,UInt8}())
+
+
+height(t::PersistentDisjointSet{T},i::T) where {T} =  get(t.heights,i,zero(UInt8))
+
+function Base.getindex(t::PersistentDisjointSet{T},i::T) where {T} 
+    while haskey(t.table,i) # In a persistent setting, writes cost memory, so path compression may not be worth the allocations.
+        i = t.table[i]      # Height balancing already guarentees finding the root in floor(lg(N)) lookups.
+    end
+    i
+end
+
+function Base.union(t::PersistentDisjointSet{T},i::T,j::T) where {T}
+    i = t[i];j=t[j]
+    if i == j return t end
+    if height(t,i) > height(t,j)
+        PersistentDisjointSet(assoc(t.table,j,i),t.heights)
+    elseif height(t,i) < height(t,j)
+        PersistentDisjointSet(assoc(t.table,i,j),t.heights)
+    else
+        PersistentDisjointSet(assoc(t.table,j,i),assoc(t.heights,i,height(t,i) + 1))
+    end     
+end
+
+function Base.show(io::IO,t::PersistentDisjointSet{T}) where {T}
+    Base.print(io,"PersistentDisjointSet{$T}")
+    Base.print(io,sort!(map(x->first(x) => t[last(x)],collect(pairs(t.table)));by=x->(last(x),first(x))))
+end

--- a/test/PersistentDisjointSetTest.jl
+++ b/test/PersistentDisjointSetTest.jl
@@ -1,0 +1,19 @@
+using FunctionalCollections
+using Test
+
+@testset "Persistent Lists" begin
+
+    @testset "UnionFind" begin
+        uf = PersistentDisjointSet{Int}()
+        uf = union(uf,2,3)
+        uf = union(uf,5,7)
+        uf = union(uf,2,4)
+        uf = union(uf,4,8)
+        @assert uf[1] == 1
+        @assert uf[1] != uf[7]
+        @assert uf[3] == uf[8]
+        @assert uf[5] == uf[7]
+        @assert uf[3] != uf[7]
+    end
+
+end


### PR DESCRIPTION
Implementation of a persistent [union find data structure](https://en.wikipedia.org/wiki/Disjoint-set_data_structure). This is useful and complementary to the [DisjointSet structure in the imperative DataStructures.jl package](https://juliacollections.github.io/DataStructures.jl/latest/disjoint_set/), because a large subset of the usecases for a disjoint set data structure turn out to be ones that are heavy on backtracking, and keeping a stack of undos around in those cases gets unwieldy very fast.